### PR TITLE
Add gcc-aarch64-linux-gnu

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN wget ${GORELEASER_DOWNLOAD_URL}; \
     rm $GORELEASER_DOWNLOAD_FILE;
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends musl-tools
+    apt-get install -y --no-install-recommends musl-tools && \
+    apt-get install -y gcc-aarch64-linux-gnu
 
 CMD ["goreleaser", "-v"]


### PR DESCRIPTION
The following files have been modified:
Added "**gcc-aarch64-linux-gnu**" in **DOCKERFILE** for arm64 support